### PR TITLE
🖱 remove scroll bar from search-box when empty

### DIFF
--- a/styles/Topics.js
+++ b/styles/Topics.js
@@ -25,7 +25,7 @@ export const SearchBoxWrapper = styled.div`
   box-shadow: 0px 5px 12px rgba(0, 0, 0, 0.1), 0px 10px 20px rgba(0, 0, 0, 0.08);
   border-radius: 10px;
   overflow: hidden;
-  overflow-y: scroll;
+  overflow-y: auto;
 
   ${'' /* Scrollbar ~ Customized for search results */} ::-webkit-scrollbar {
     background: transparent;


### PR DESCRIPTION
The scroll bar shows up only when suggestions are shown.

---

### Current Version :

![image](https://user-images.githubusercontent.com/31207418/72732704-de8bfb80-3b5b-11ea-8d13-983285123268.png)


### New Search Bar : 

![image](https://user-images.githubusercontent.com/31207418/72732758-01b6ab00-3b5c-11ea-8174-c46e11bef831.png)
